### PR TITLE
Fix missing API key error in llm module

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -1,8 +1,25 @@
+"""OpenAI LLM helper."""
+
+from __future__ import annotations
+
+import os
 from openai import OpenAI
 from dotenv import dotenv_values
 
-env = dotenv_values(".envrc")
-client = OpenAI(api_key=env["OPENAI_API_KEY"])
+
+def _load_api_key() -> str | None:
+    """Load ``OPENAI_API_KEY`` from ``.envrc`` or environment variables."""
+    env = dotenv_values(".envrc")
+    return env.get("OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY")
+
+
+API_KEY = _load_api_key()
+if not API_KEY:
+    raise EnvironmentError(
+        "OPENAI_API_KEY not found. Set it in a .envrc file or as an environment variable."
+    )
+
+client = OpenAI(api_key=API_KEY)
 
 def llm(prompt, model="gpt-4o-mini"):
     response = client.chat.completions.create(


### PR DESCRIPTION
## Summary
- handle missing `.envrc` by checking environment variables in `llm.py`

## Testing
- `python -m py_compile app/llm.py`
- `python -m py_compile main.py app/__init__.py app/embedder.py app/llm.py app/prompt_builder.py app/rag_pipeline.py app/retriever.py app/utils.py script.py`


------
https://chatgpt.com/codex/tasks/task_e_688aa438edb08330a07566798a4248e2